### PR TITLE
refactor: remove legacy params def

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,9 @@ repos:
         language: system
         stages: [commit]
         always_run: true
+      - id: build-packages
+        name: Build Packages
+        entry: make build
+        language: system
+        stages: [ commit ]
+        always_run: true

--- a/app/ante/tabi/captains.go
+++ b/app/ante/tabi/captains.go
@@ -42,8 +42,6 @@ func (cld CaptainsRestrictionDecorator) AnteHandle(
 func (cld CaptainsRestrictionDecorator) restrict(ctx sdk.Context, msgs []sdk.Msg) error {
 	for _, msg := range msgs {
 		switch msg := msg.(type) {
-		case *captainstypes.MsgUpdateParams:
-			return fmt.Errorf("msg %s is not allowed currenlty", msg.String())
 		case *captainstypes.MsgCreateCaptainNode,
 			*captainstypes.MsgUpdateSaleLevel,
 			*captainstypes.MsgClaimComputingPower,

--- a/app/app.go
+++ b/app/app.go
@@ -394,7 +394,6 @@ func NewTabi(
 		appCodec,
 		authtypes.NewModuleAddress(govtypes.ModuleName),
 		keys[claimstypes.StoreKey],
-		app.GetSubspace(claimstypes.ModuleName),
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.CaptainsKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -325,7 +325,6 @@ func NewTabi(
 		appCodec,
 		authtypes.NewModuleAddress(govtypes.ModuleName),
 		keys[minttypes.StoreKey],
-		app.GetSubspace(minttypes.ModuleName),
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.DistrKeeper,
@@ -845,7 +844,6 @@ func initParamsKeeper(
 	paramsKeeper.Subspace(authtypes.ModuleName)
 	paramsKeeper.Subspace(banktypes.ModuleName)
 	paramsKeeper.Subspace(stakingtypes.ModuleName)
-	paramsKeeper.Subspace(minttypes.ModuleName)
 	paramsKeeper.Subspace(distrtypes.ModuleName)
 	paramsKeeper.Subspace(slashingtypes.ModuleName)
 	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govv1.ParamKeyTable())
@@ -856,6 +854,7 @@ func initParamsKeeper(
 	paramsKeeper.Subspace(evmtypes.ModuleName).WithKeyTable(evmtypes.ParamKeyTable()) //nolint: staticcheck
 	paramsKeeper.Subspace(feemarkettypes.ModuleName).WithKeyTable(feemarkettypes.ParamKeyTable())
 	// tabi subspaces
+	paramsKeeper.Subspace(minttypes.ModuleName)
 	paramsKeeper.Subspace(claimstypes.ModuleName)
 	paramsKeeper.Subspace(captainnodetypes.ModuleName)
 

--- a/x/captains/keeper/msg_server.go
+++ b/x/captains/keeper/msg_server.go
@@ -25,7 +25,6 @@ func NewMsgServerImpl(keeper *Keeper) types.MsgServer {
 }
 
 // UpdateParams implement the interface of types.MsgServer
-// NOTE: currently doesn't support in-module params, use x/params instead.
 func (m msgServer) UpdateParams(
 	goCtx context.Context,
 	msg *types.MsgUpdateParams,

--- a/x/captains/types/params.go
+++ b/x/captains/types/params.go
@@ -4,18 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
-
-const (
-	DefaultParamSpace = ModuleName
-)
-
-// ParamKeyTable for captains node
-func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
-}
 
 // NewParams creates a Params.
 func NewParams(
@@ -52,17 +41,6 @@ func DefaultParams() Params {
 		CurrentSaleLevel:                   1,
 		AuthorizedMembers:                  nil,
 	}
-}
-
-// ParamSetPairs implements params.ParamSet
-// FIXME: we need this!
-func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return nil
-}
-
-// GetParamSpace implements params.ParamStruct
-func (p *Params) GetParamSpace() string {
-	return DefaultParamSpace
 }
 
 // Validate returns err if the Params is invalid

--- a/x/claims/keeper/keeper.go
+++ b/x/claims/keeper/keeper.go
@@ -5,18 +5,16 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/tabilabs/tabi/x/claims/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-
-	"github.com/tabilabs/tabi/x/claims/types"
 )
 
 type Keeper struct {
-	cdc        codec.Codec
-	storeKey   storetypes.StoreKey
-	paramSpace paramtypes.Subspace
+	cdc      codec.Codec
+	storeKey storetypes.StoreKey
 
 	// cosmos keepers
 	authKeeper types.AccountKeeper
@@ -31,8 +29,8 @@ type Keeper struct {
 
 // NewKeeper returns a mint keeper
 func NewKeeper(cdc codec.Codec, authority sdk.AccAddress,
-	key storetypes.StoreKey, paramSpace paramtypes.Subspace,
-	ak types.AccountKeeper, bk types.BankKeeper, ck types.CaptainsKeeper,
+	key storetypes.StoreKey, ak types.AccountKeeper,
+	bk types.BankKeeper, ck types.CaptainsKeeper,
 ) Keeper {
 	// ensure mint module account is set
 	if addr := ak.GetModuleAddress(types.ModuleName); addr == nil {
@@ -42,7 +40,6 @@ func NewKeeper(cdc codec.Codec, authority sdk.AccAddress,
 	keeper := Keeper{
 		storeKey:       key,
 		cdc:            cdc,
-		paramSpace:     paramSpace.WithKeyTable(types.ParamKeyTable()),
 		authKeeper:     ak,
 		bankKeeper:     bk,
 		captainsKeeper: ck,

--- a/x/claims/types/genesis.go
+++ b/x/claims/types/genesis.go
@@ -13,9 +13,3 @@ func DefaultGenesisState() *GenesisState {
 		Params: DefaultParams(),
 	}
 }
-
-// ValidateGenesis validates the provided staking genesis state to ensure the
-// expected invariants holds. (i.e. params in correct bounds, no duplicate validators)
-func ValidateGenesis(gs *GenesisState) error {
-	return gs.Params.ValidateBasic()
-}

--- a/x/claims/types/params.go
+++ b/x/claims/types/params.go
@@ -2,19 +2,7 @@ package types
 
 import (
 	tabitypes "github.com/tabilabs/tabi/types"
-
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
-
-// default paramspace for params keeper
-const (
-	DefaultParamSpace = ModuleName
-)
-
-// ParamTable for mint module
-func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
-}
 
 // DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
@@ -22,16 +10,6 @@ func DefaultParams() Params {
 		EnableClaims: true,
 		ClaimsDenom:  tabitypes.AttoVeTabi,
 	}
-}
-
-// ParamSetPairs implements params.ParamSet
-func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return nil
-}
-
-// GetParamSpace implements params.ParamStruct
-func (p *Params) GetParamSpace() string {
-	return DefaultParamSpace
 }
 
 // Validate returns err if the Params is invalid

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -5,19 +5,17 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
+	"github.com/tabilabs/tabi/x/mint/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-
-	"github.com/tabilabs/tabi/x/mint/types"
 )
 
 // keeper of the mint store
 type Keeper struct {
-	cdc        codec.Codec
-	storeKey   storetypes.StoreKey
-	paramSpace paramtypes.Subspace
+	cdc      codec.Codec
+	storeKey storetypes.StoreKey
 
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
@@ -31,7 +29,7 @@ type Keeper struct {
 
 // NewKeeper returns a mint keeper
 func NewKeeper(cdc codec.Codec, authority sdk.AccAddress, key storetypes.StoreKey,
-	paramSpace paramtypes.Subspace, ak types.AccountKeeper, bk types.BankKeeper, dk types.DistrKeeper,
+	ak types.AccountKeeper, bk types.BankKeeper, dk types.DistrKeeper,
 	feeCollectorName string,
 ) Keeper {
 	// ensure mint module account is set
@@ -42,7 +40,6 @@ func NewKeeper(cdc codec.Codec, authority sdk.AccAddress, key storetypes.StoreKe
 	keeper := Keeper{
 		storeKey:         key,
 		cdc:              cdc,
-		paramSpace:       paramSpace.WithKeyTable(types.ParamKeyTable()),
 		accountKeeper:    ak,
 		bankKeeper:       bk,
 		distrKeeper:      dk,

--- a/x/mint/simulation/params.go
+++ b/x/mint/simulation/params.go
@@ -18,7 +18,7 @@ func ParamChanges(r *rand.Rand) []simtypes.ParamChange {
 	return []simtypes.ParamChange{
 		simulation.NewSimParamChange(
 			types.ModuleName,
-			string(types.KeyInflation),
+			"Inflation",
 			func(r *rand.Rand) string {
 				return fmt.Sprintf("\"%s\"", GenInflation(r))
 			},

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -1,41 +1,21 @@
 package types
 
 import (
-	fmt "fmt"
+	"fmt"
 	"strings"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"gopkg.in/yaml.v2"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	evm "github.com/tabilabs/tabi/x/evm/types"
-
-	"gopkg.in/yaml.v2"
-)
-
-// default paramspace for params keeper
-const (
-	DefaultParamSpace = "mint"
-)
-
-// Parameter store key
-var (
-	// params store for inflation params
-	KeyInflation             = []byte("Inflation")
-	KeyMintDenom             = []byte("MintDenom")
-	KeyInflationDistribution = []byte("InflationDistribution")
 )
 
 var (
 	DefaultMintDenom = evm.DefaultEVMDenom
 	DefaultInflation = sdk.NewDecWithPrec(20, 2) // 20%
 )
-
-// ParamTable for mint module
-func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
-}
 
 func NewParams(
 	mintDenom string,
@@ -59,19 +39,6 @@ func DefaultParams() Params {
 func (p Params) String() string {
 	out, _ := yaml.Marshal(p)
 	return string(out)
-}
-
-// ParamSetPairs implements params.ParamSet
-func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return paramtypes.ParamSetPairs{
-		paramtypes.NewParamSetPair(KeyInflation, &p.Inflation, validateInflation),
-		paramtypes.NewParamSetPair(KeyMintDenom, &p.MintDenom, validateMintDenom),
-	}
-}
-
-// GetParamSpace implements params.ParamStruct
-func (p *Params) GetParamSpace() string {
-	return DefaultParamSpace
 }
 
 // Validate returns err if the Params is invalid


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new pre-commit step to trigger a build process during commits.

- **Refactor**
  - Removed handling for `MsgUpdateParams` in the `CaptainsRestrictionDecorator` to simplify logic.
  - Streamlined the initialization in `NewTabi` by removing unnecessary subspace calls.
  - Updated `UpdateParams` function to recommend using `x/params` for parameter handling.
  - Removed various parameter handling functions and constants across multiple modules (`captains`, `claims`, `mint`).

- **Bug Fixes**
  - Corrected key naming in `ParamChanges` function from `types.KeyInflation` to `"Inflation"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->